### PR TITLE
Fix broken tests

### DIFF
--- a/__mocks__/next/image.js
+++ b/__mocks__/next/image.js
@@ -1,0 +1,22 @@
+// Mock for next/image to prevent fill prop warnings in tests
+const MockImage = (props) => {
+  // Remove Next.js specific props that shouldn't be passed to DOM
+  const { 
+    fill, 
+    priority, 
+    sizes, 
+    quality, 
+    placeholder, 
+    blurDataURL, 
+    onLoad,
+    onError,
+    loader,
+    unoptimized,
+    ...imgProps 
+  } = props;
+  
+  // eslint-disable-next-line @next/next/no-img-element
+  return <img {...imgProps} alt={props.alt || ""} />;
+};
+
+export default MockImage;

--- a/app/courts/[id]/page.test.tsx
+++ b/app/courts/[id]/page.test.tsx
@@ -1,13 +1,7 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { act } from "react";
 
-// Mock next/image to render a simple img and ignore boolean props that cause React warnings
-jest.mock("next/image", () => (props: any) => {
-  // Remove boolean props that cause React warnings
-  // eslint-disable-next-line @next/next/no-img-element
-  const { fill, priority, ...rest } = props;
-  return <img {...rest} alt={props.alt} />;
-});
+// next/image is mocked globally in jest.config.js
 
 // Mock next/navigation
 const mockBack = jest.fn();

--- a/app/courts/page.test.tsx
+++ b/app/courts/page.test.tsx
@@ -1,10 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import CourtsPage from "./page";
 
-// Mock next/image to render a simple img
-jest.mock("next/image", () => (props: any) => (
-  <img {...props} alt={props.alt} />
-));
+// next/image is mocked globally in jest.config.js
 
 // Mock next/navigation
 const mockPush = jest.fn();

--- a/app/dashboard/owner/page.test.tsx
+++ b/app/dashboard/owner/page.test.tsx
@@ -1,14 +1,7 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import OwnerDashboard from "./page";
 
-// Mock next/image to avoid errors in Jest
-jest.mock("next/image", () => ({
-  __esModule: true,
-  default: (props: any) => {
-    // eslint-disable-next-line @next/next/no-img-element
-    return <img {...props} />;
-  },
-}));
+// next/image is mocked globally in jest.config.js
 
 // Mock next/navigation
 const mockPush = jest.fn();

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,9 +21,10 @@ const customJestConfig = {
   // This allows imports from both installed packages and local files
   moduleDirectories: ['node_modules', '<rootDir>/'],
   
-  // Add path mapping for the @ alias
+  // Add path mapping for the @ alias and mock next/image
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
+    '^next/image$': '<rootDir>/__mocks__/next/image.js',
   },
 
   // 👇 Add this to handle React 18/19 export conditions

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -38,6 +38,24 @@ if (typeof window !== "undefined") {
   });
 }
 
+// Mock window.location methods to prevent JSDOM "not implemented" errors
+// Delete first to avoid "Cannot redefine property" error
+delete (window as any).location;
+(window as any).location = {
+  href: "http://localhost:3000",
+  origin: "http://localhost:3000",
+  protocol: "http:",
+  host: "localhost:3000",
+  hostname: "localhost",
+  port: "3000",
+  pathname: "/",
+  search: "",
+  hash: "",
+  assign: jest.fn(),
+  replace: jest.fn(),
+  reload: jest.fn(),
+};
+
 // Mock IntersectionObserver
 class MockIntersectionObserver {
   observe = jest.fn();
@@ -74,3 +92,6 @@ global.requestAnimationFrame = (callback) => {
 global.cancelAnimationFrame = (id) => {
   clearTimeout(id);
 };
+
+// Mock alert to prevent errors in tests
+global.alert = jest.fn();


### PR DESCRIPTION
Clean up test console output by mocking `next/image` and `window.location`.

This PR addresses console warnings and errors during test runs, specifically:
- Resolving React warnings about boolean `fill` attributes from `next/image` by introducing a global mock.
- Fixing JSDOM "not implemented" errors for `window.location` navigation methods by providing a comprehensive mock.
- Removing redundant `next/image` mocks from individual test files for consistency.